### PR TITLE
Reduce Timestamp granularity in created / updated consent timestamps

### DIFF
--- a/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
+++ b/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
@@ -39,7 +39,7 @@ import com.iabtcf.utils.IntIterator;
  */
 class BitWriter {
     private static final long[] LONG_MASKS = new long[Long.SIZE + 1];
-    private static final long DAY_IN_DECISECONDS = 864000;   // 24 * 60 * 60 * 10
+    private static final long DAY_AS_DECISECONDS = 864_000; // 24 * 60 * 60 * 10
 
     static {
         for (int i = 0; i < Long.SIZE; i++) {
@@ -119,9 +119,9 @@ class BitWriter {
      * Writes an iabtcf encoded instant value, with Days precision only.
      */
     public void writeDays(Instant i, FieldDefs field) {
-        long timeInDeciseconds = i.toEpochMilli() / 100;
-        long precisionToDrop = timeInDeciseconds % DAY_IN_DECISECONDS;
-        write(timeInDeciseconds - precisionToDrop, field);
+        long timeAsDeciseconds = i.toEpochMilli() / 100;
+        long precisionToDrop = timeAsDeciseconds % DAY_AS_DECISECONDS;
+        write(timeAsDeciseconds - precisionToDrop, field);
     }
 
     /**

--- a/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
+++ b/iabtcf-encoder/src/main/java/com/iabtcf/encoder/BitWriter.java
@@ -39,6 +39,7 @@ import com.iabtcf.utils.IntIterator;
  */
 class BitWriter {
     private static final long[] LONG_MASKS = new long[Long.SIZE + 1];
+    private static final long DAY_IN_DECISECONDS = 864000;   // 24 * 60 * 60 * 10
 
     static {
         for (int i = 0; i < Long.SIZE; i++) {
@@ -112,6 +113,15 @@ class BitWriter {
      */
     public void write(Instant i, FieldDefs field) {
         write(i.toEpochMilli() / 100, field);
+    }
+
+    /**
+     * Writes an iabtcf encoded instant value, with Days precision only.
+     */
+    public void writeDays(Instant i, FieldDefs field) {
+        long timeInDeciseconds = i.toEpochMilli() / 100;
+        long precisionToDrop = timeInDeciseconds % DAY_IN_DECISECONDS;
+        write(timeInDeciseconds - precisionToDrop, field);
     }
 
     /**

--- a/iabtcf-encoder/src/main/java/com/iabtcf/encoder/TCStringEncoder.java
+++ b/iabtcf-encoder/src/main/java/com/iabtcf/encoder/TCStringEncoder.java
@@ -265,8 +265,8 @@ public interface TCStringEncoder {
         private String encodeCoreString() {
             BitWriter bitWriter = new BitWriter();
             bitWriter.write(version, CORE_VERSION);
-            bitWriter.write(created, CORE_CREATED);
-            bitWriter.write(updated, CORE_LAST_UPDATED);
+            bitWriter.writeDays(created, CORE_CREATED);
+            bitWriter.writeDays(updated, CORE_LAST_UPDATED);
             bitWriter.write(cmpId, CORE_CMP_ID);
             bitWriter.write(cmpVersion, CORE_CMP_VERSION);
             bitWriter.write(consentScreen, CORE_CONSENT_SCREEN);

--- a/iabtcf-encoder/src/main/java/com/iabtcf/encoder/TCStringEncoder.java
+++ b/iabtcf-encoder/src/main/java/com/iabtcf/encoder/TCStringEncoder.java
@@ -417,11 +417,18 @@ public interface TCStringEncoder {
             return this;
         }
 
+        /**
+         * In V2, the encoded value will be rounded to the day.
+         * It should also be the same value than {@link #lastUpdated}.
+         */
         public Builder created(Instant created) {
             this.created = created;
             return this;
         }
 
+        /**
+         * In V2, the encoded value will be rounded to the day.
+         */
         public Builder lastUpdated(Instant updated) {
             this.updated = updated;
             return this;

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
@@ -336,7 +336,7 @@ public class BitWriterTest {
         BitWriter bw = new BitWriter();
         bw.write(2, 6);
         bw.write(Instant.parse("2020-01-26T17:01:00Z").toEpochMilli() / 100, 36);
-        bw.write(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
+        bw.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_CREATED);
         bw.write(675, FieldDefs.CORE_CMP_ID);
         bw.write(2, FieldDefs.CORE_CMP_VERSION);
         bw.write(1, FieldDefs.CORE_CONSENT_SCREEN);
@@ -377,12 +377,12 @@ public class BitWriterTest {
 
         String str = bw.toBase64();
 
-        assertEquals("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA", str);
+        assertEquals("COtybn4PA9dwAKjACBENAPCIAEBAAECAAIAAAAAAAAAA", str);
 
         TCString tcModel = TCString.decode(str);
         assertEquals(2, tcModel.getVersion());
         assertEquals(Instant.parse("2020-01-26T17:01:00Z"), tcModel.getCreated());
-        assertEquals(Instant.parse("2021-02-02T17:01:00Z"), tcModel.getLastUpdated());
+        assertEquals(Instant.parse("2021-02-02T00:00:00Z"), tcModel.getLastUpdated());
         assertEquals(675, tcModel.getCmpId());
         assertEquals(2, tcModel.getCmpVersion());
         assertEquals(1, tcModel.getConsentScreen());
@@ -403,24 +403,24 @@ public class BitWriterTest {
      */
     @Test
     public void testWriteDateDaysIgnoresBelowDayLevel() {
-        BitWriter bw1 = new BitWriter();
-        bw1.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
+        BitWriter bwCompleteDate = new BitWriter();
+        bwCompleteDate.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
 
-        BitWriter bw2 = new BitWriter();
-        bw2.writeDays(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
+        BitWriter bwWithOnlyDays = new BitWriter();
+        bwWithOnlyDays.writeDays(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
 
-        assertEquals(bw1.toBase64(), bw2.toBase64());
+        assertEquals(bwCompleteDate.toBase64(), bwWithOnlyDays.toBase64());
     }
 
     @Test
     public void testWriteDateDays() {
-        BitWriter bwComplete = new BitWriter();
-        bwComplete.write(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
+        BitWriter bwCompleteDate = new BitWriter();
+        bwCompleteDate.write(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
 
         BitWriter bwDays = new BitWriter();
         bwDays.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
 
-        assertEquals(bwComplete.toBase64(), bwDays.toBase64());
+        assertEquals(bwCompleteDate.toBase64(), bwDays.toBase64());
     }
 
     @Test
@@ -438,7 +438,6 @@ public class BitWriterTest {
         // Day is different than UTC time
         asiaCalendar.set(Calendar.DAY_OF_MONTH, 3);
         asiaCalendar.set(Calendar.HOUR_OF_DAY, 1);
-
 
         BitWriter bwAsia = new BitWriter();
         bwAsia.writeDays(asiaCalendar.toInstant(), FieldDefs.CORE_LAST_UPDATED);

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/BitWriterTest.java
@@ -29,6 +29,8 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.time.Instant;
+import java.util.Calendar;
+import java.util.TimeZone;
 
 import org.junit.Test;
 
@@ -394,6 +396,62 @@ public class BitWriterTest {
         assertThat(tcModel.getPurposesLITransparency(), matchInts(2, 9));
         assertTrue(tcModel.getPurposeOneTreatment());
         assertEquals("AA", tcModel.getPublisherCC());
+    }
+
+    /**
+     * Check that hour, minutes, seconds and milliseconds are ignored when encoding a date days.
+     */
+    @Test
+    public void testWriteDateDaysIgnoresBelowDayLevel() {
+        BitWriter bw1 = new BitWriter();
+        bw1.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
+
+        BitWriter bw2 = new BitWriter();
+        bw2.writeDays(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
+
+        assertEquals(bw1.toBase64(), bw2.toBase64());
+    }
+
+    @Test
+    public void testWriteDateDays() {
+        BitWriter bwComplete = new BitWriter();
+        bwComplete.write(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
+
+        BitWriter bwDays = new BitWriter();
+        bwDays.writeDays(Instant.parse("2021-02-02T17:01:00Z"), FieldDefs.CORE_LAST_UPDATED);
+
+        assertEquals(bwComplete.toBase64(), bwDays.toBase64());
+    }
+
+    @Test
+    public void testWriteDateDaysTimeZone() {
+        Calendar gmtCalendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"));
+        gmtCalendar.set(Calendar.YEAR, 2021);
+        gmtCalendar.set(Calendar.MONTH, Calendar.FEBRUARY);
+        gmtCalendar.set(Calendar.DAY_OF_MONTH, 2);
+        gmtCalendar.set(Calendar.HOUR_OF_DAY, 20);
+
+        // GMT + 5:30
+        Calendar asiaCalendar = Calendar.getInstance(TimeZone.getTimeZone("Asia/Calcutta"));
+        asiaCalendar.set(Calendar.YEAR, 2021);
+        asiaCalendar.set(Calendar.MONTH, Calendar.FEBRUARY);
+        // Day is different than UTC time
+        asiaCalendar.set(Calendar.DAY_OF_MONTH, 3);
+        asiaCalendar.set(Calendar.HOUR_OF_DAY, 1);
+
+
+        BitWriter bwAsia = new BitWriter();
+        bwAsia.writeDays(asiaCalendar.toInstant(), FieldDefs.CORE_LAST_UPDATED);
+
+        BitWriter bwGmt = new BitWriter();
+        bwGmt.writeDays(gmtCalendar.toInstant(), FieldDefs.CORE_LAST_UPDATED);
+
+        assertEquals(bwGmt.toBase64(), bwAsia.toBase64());
+
+        BitWriter bwDays = new BitWriter();
+        bwDays.write(Instant.parse("2021-02-02T00:00:00Z"), FieldDefs.CORE_LAST_UPDATED);
+
+        assertEquals(bwGmt.toBase64(), bwDays.toBase64());
     }
 
     @Test

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
@@ -1,6 +1,5 @@
 package com.iabtcf.encoder;
 
-import static com.iabtcf.encoder.utils.TestUtils.toDeci;
 import static com.iabtcf.encoder.utils.TestUtils.toDeciDays;
 import static com.iabtcf.test.utils.IntIterableMatcher.matchInts;
 import static org.junit.Assert.assertEquals;
@@ -46,7 +45,7 @@ import com.iabtcf.v2.RestrictionType;
 public class TCStringV2EncoderTest {
 
     private final Instant created = Instant.now();
-    private final Instant updated = created.plus(1, ChronoUnit.DAYS);
+    private final Instant updated = created.plus(1, ChronoUnit.HOURS);
     private TCStringEncoder.Builder encoderBuilder;
 
     @Before

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/TCStringV2EncoderTest.java
@@ -1,6 +1,7 @@
 package com.iabtcf.encoder;
 
 import static com.iabtcf.encoder.utils.TestUtils.toDeci;
+import static com.iabtcf.encoder.utils.TestUtils.toDeciDays;
 import static com.iabtcf.test.utils.IntIterableMatcher.matchInts;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -45,7 +46,7 @@ import com.iabtcf.v2.RestrictionType;
 public class TCStringV2EncoderTest {
 
     private final Instant created = Instant.now();
-    private final Instant updated = created.plus(1, ChronoUnit.HOURS);
+    private final Instant updated = created.plus(1, ChronoUnit.DAYS);
     private TCStringEncoder.Builder encoderBuilder;
 
     @Before
@@ -126,8 +127,8 @@ public class TCStringV2EncoderTest {
 
         assertEquals(1, tcf.split("\\.").length);
         assertEquals(2, decoded.getVersion());
-        assertEquals(toDeci(created), decoded.getCreated());
-        assertEquals(toDeci(updated), decoded.getLastUpdated());
+        assertEquals(toDeciDays(created), decoded.getCreated());
+        assertEquals(toDeciDays(updated), decoded.getLastUpdated());
         assertEquals(1, decoded.getCmpId());
         assertEquals(12, decoded.getCmpVersion());
         assertEquals(1, decoded.getConsentScreen());
@@ -453,7 +454,7 @@ public class TCStringV2EncoderTest {
 
     @Test
     public void testToTCString() {
-        TCString tcStr = TCString.decode("COtybn4PA_zT4KjACBENAPCIAEBAAECAAIAAAAAAAAAA");
+        TCString tcStr = TCString.decode("COtwGEAPA9dwAKjACBENAPCIAEBAAECAAIAAAAAAAAAA");
         TCStringEncoder.Builder b = TCStringEncoder.newBuilder(tcStr);
         TCString tcStr1 = b.toTCString();
         assertEquals(tcStr, tcStr1);

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
@@ -28,4 +28,10 @@ public class TestUtils {
        return Instant.ofEpochMilli((instant.toEpochMilli() / 100) * 100);
     }
 
+    public static Instant toDeciDays(Instant instant) {
+        long deciseconds = instant.toEpochMilli() / 100;
+        long precisionToRemove = deciseconds % (24 * 60 * 60 * 10);
+        return Instant.ofEpochMilli((deciseconds - precisionToRemove) * 100);
+    }
+
 }

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
@@ -35,5 +35,4 @@ public class TestUtils {
         long precisionToRemove = deciseconds % DAY_AS_DECISECONDS;
         return Instant.ofEpochMilli((deciseconds - precisionToRemove) * 100);
     }
-
 }

--- a/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
+++ b/iabtcf-encoder/src/test/java/com/iabtcf/encoder/utils/TestUtils.java
@@ -24,13 +24,15 @@ import java.time.Instant;
 
 public class TestUtils {
 
+    private static final long DAY_AS_DECISECONDS = 24 * 60 * 60 * 10;
+
     public static Instant toDeci(Instant instant) {
        return Instant.ofEpochMilli((instant.toEpochMilli() / 100) * 100);
     }
 
     public static Instant toDeciDays(Instant instant) {
         long deciseconds = instant.toEpochMilli() / 100;
-        long precisionToRemove = deciseconds % (24 * 60 * 60 * 10);
+        long precisionToRemove = deciseconds % DAY_AS_DECISECONDS;
         return Instant.ofEpochMilli((deciseconds - precisionToRemove) * 100);
     }
 


### PR DESCRIPTION
Do not include hour, minute, second, milliseconds information in consent string timestamp, as described in the latest specification changes: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/pull/306